### PR TITLE
Updated module, README to include github reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ package main
 
 import (
     "fmt"
-    "govinci/core"
+    "github.com/grahms/govinci/core"
 )
 
 func main() {
@@ -49,6 +49,8 @@ func main() {
 
 ### `app.go`
 ```go
+import "github.com/grahms/govinci/core"
+
 func App(ctx *core.Context) core.View {
     return core.SafeArea(
         core.Scroll(
@@ -66,6 +68,8 @@ func App(ctx *core.Context) core.View {
 
 ### `profile.go`
 ```go
+import "github.com/grahms/govinci/core"
+
 func ProfileHeader() core.View {
     return core.Column(
         core.Image("https://example.com/avatar.jpg", core.UseStyle(core.Style{BorderRadius: 40})),
@@ -94,6 +98,8 @@ func Stat(label, value string) core.View {
 
 ### `posts.go`
 ```go
+import "github.com/grahms/govinci/core"
+
 func PostList() core.View {
     return core.Column(
         Post("Enjoying the Govinci project! 🚀"),

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module govinci
+module github.com/grahms/govinci
 
 go 1.23.0


### PR DESCRIPTION
To allow this framework to be importable in other projects, the module should be defined with the github project url.
Additionally, to make the examples easier to copy/paste, I added the govinci import to all files.