### PR TITLE
Add generic event helper and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,22 @@ core.MatchBool(
 
 This leads to beautiful, logical component trees that **read like prose**.
 
+## 🎯 Event Handlers
+
+You can attach callbacks to any element using the generic `On` helper or the
+`ButtonWithEvent` constructor for buttons.
+
+```go
+core.Column(
+    core.Text("Tap the box"),
+    core.On("Click", func() { fmt.Println("Column clicked") }),
+)
+
+core.ButtonWithEvent("Hold", "TouchStart", func() {
+    fmt.Println("Button touched")
+})
+```
+
 ---
 
 ## 📐 Architecture

--- a/core/behavioral_props.go
+++ b/core/behavioral_props.go
@@ -9,8 +9,19 @@ type behaviorFunc func(*Node)
 func (f behaviorFunc) Apply(n *Node) {
 	f(n)
 }
-func OnClick(handler func()) BehaviorProp {
+func On(event string, handler func()) BehaviorProp {
 	return behaviorFunc(func(n *Node) {
-		n.Props["onClick"] = registerCallback(handler)
+		if n.Props == nil {
+			n.Props = map[string]any{}
+		}
+		n.Props["on"+event] = registerCallback(handler)
 	})
+}
+
+func OnClick(handler func()) BehaviorProp {
+	return On("Click", handler)
+}
+
+func OnTouch(handler func()) BehaviorProp {
+	return On("Touch", handler)
 }

--- a/core/button.go
+++ b/core/button.go
@@ -18,3 +18,24 @@ func Button(label string, onClick func(), styleProps ...StyleProp) View {
 		}
 	})
 }
+
+func ButtonWithEvent(label string, event string, handler func(), styleProps ...StyleProp) View {
+	return ComponentFunc(func(ctx *Context) *Node {
+		base := ctx.Theme().Components.Button
+		style := &base
+		for _, sp := range styleProps {
+			sp.Apply(style)
+		}
+
+		props := map[string]any{
+			"label": label,
+		}
+		props["on"+event] = registerCallback(handler)
+
+		return &Node{
+			Type:  "Button",
+			Props: props,
+			Style: style,
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- add `On` helper and `OnTouch` convenience function
- support custom button events via `ButtonWithEvent`
- document event handling examples in README

