### PR TITLE
fix: adjust import paths and module name to match github repo

### DIFF
--- a/examples/chat/main.go
+++ b/examples/chat/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	. "govinci/core"
-	"govinci/htmlout"
+	. "github.com/GraHms/govinci/core"
+	"github.com/GraHms/govinci/htmlout"
 	"os"
 )
 

--- a/examples/components.go
+++ b/examples/components.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"fmt"
-	"govinci/core"
-	"govinci/render"
+	"github.com/GraHms/govinci/core"
+	"github.com/GraHms/govinci/render"
 )
 
 func App(ctx *core.Context) core.View {

--- a/examples/fintechapp/main.go
+++ b/examples/fintechapp/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"govinci/core"
-	"govinci/htmlout"
+	"github.com/GraHms/govinci/core"
+	"github.com/GraHms/govinci/htmlout"
 	"os"
 )
 

--- a/examples/layout/main.go
+++ b/examples/layout/main.go
@@ -1,9 +1,10 @@
 package main
 
 import (
-	core "govinci/core"
-	"govinci/htmlout"
 	"os"
+
+	"github.com/GraHms/govinci/core"
+	"github.com/GraHms/govinci/htmlout"
 )
 
 func AppLayoutExample() core.View {

--- a/examples/runtime/main.go
+++ b/examples/runtime/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"fmt"
-	"govinci/core"
-	"govinci/htmlout"
+	"github.com/GraHms/govinci/core"
+	"github.com/GraHms/govinci/htmlout"
 )
 
 func App(ctx *core.Context) core.View {

--- a/examples/social/pages.go
+++ b/examples/social/pages.go
@@ -1,7 +1,7 @@
 package social
 
 import (
-	. "govinci/core"
+	. "github.com/GraHms/govinci/core"
 )
 
 func HomePage(ctx *Context) View {

--- a/examples/social/tab.go
+++ b/examples/social/tab.go
@@ -1,6 +1,6 @@
 package social
 
-import "govinci/core"
+import "github.com/GraHms/govinci/core"
 
 func TabButton(icon, tab string, selected core.State[string]) core.View {
 	isActive := selected.Get() == tab

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/grahms/govinci
+module github.com/GraHms/govinci
 
 go 1.23.0

--- a/hooks/effect.go
+++ b/hooks/effect.go
@@ -1,7 +1,7 @@
 package hooks
 
 import (
-	"govinci/core"
+	"github.com/GraHms/govinci/core"
 	"reflect"
 )
 

--- a/hooks/interval.go
+++ b/hooks/interval.go
@@ -2,7 +2,7 @@ package hooks
 
 import (
 	"fmt"
-	"govinci/core"
+	"github.com/GraHms/govinci/core"
 	"sync"
 	"time"
 )

--- a/htmlout/export.go
+++ b/htmlout/export.go
@@ -2,7 +2,7 @@ package htmlout
 
 import (
 	"fmt"
-	"govinci/core"
+	"github.com/GraHms/govinci/core"
 	"strings"
 )
 

--- a/jsonout/export.go
+++ b/jsonout/export.go
@@ -2,7 +2,7 @@ package jsonout
 
 import (
 	"encoding/json"
-	"govinci/core"
+	"github.com/GraHms/govinci/core"
 )
 
 func Export(node *core.Node) string {

--- a/main.go
+++ b/main.go
@@ -3,8 +3,8 @@
 package main
 
 import (
-	"govinci/core"
-	"govinci/render"
+	"github.com/GraHms/govinci/core"
+	"github.com/GraHms/govinci/render"
 	"myapp/app"
 )
 

--- a/reconcile/patch.go
+++ b/reconcile/patch.go
@@ -2,7 +2,7 @@ package reconcile
 
 import (
 	"fmt"
-	"govinci/core"
+	"github.com/GraHms/govinci/core"
 )
 
 // Patch represents a minimal change set between two Node trees

--- a/render/manager.go
+++ b/render/manager.go
@@ -2,8 +2,8 @@ package render
 
 import (
 	"encoding/json"
-	"govinci/core"
-	"govinci/reconcile"
+	"github.com/GraHms/govinci/core"
+	"github.com/GraHms/govinci/reconcile"
 )
 
 type Manager struct {

--- a/wasm/main.go
+++ b/wasm/main.go
@@ -4,10 +4,10 @@ package main
 
 import (
 	"encoding/json"
-	"govinci/core"
-	. "govinci/examples/social"
-	"govinci/hooks"
-	"govinci/render"
+	"github.com/GraHms/govinci/core"
+	. "github.com/GraHms/govinci/examples/social"
+	"github.com/GraHms/govinci/hooks"
+	"github.com/GraHms/govinci/render"
 	"syscall/js"
 )
 


### PR DESCRIPTION
this pr fixes some of import issues,hereby:

- replaced the use of `govinci/...` for the full module path `github.com/GraHms/govinci/...` since govinci is not in std
- adjusted the module name in `go.mod` (`github.com/grahms/govinci`) which didnt match the github repo name (`GraHms`) since resolution is case-sensitive (the match is just to avoid confusion)

